### PR TITLE
Fix error cell and rename dataframes.

### DIFF
--- a/Data Manipulation.ipynb
+++ b/Data Manipulation.ipynb
@@ -88,8 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = ZRI_MF_long.groupby('RegionName')[['ZRI', 'RegionID']].agg({'ZRI':'mean', 'ZRI':'std'})\n",
-    "df.columns = ['mean', 'std']"
+    "ZRI_std_mean = ZRI_MF_long.groupby('RegionName')['ZRI'].agg({'mean', 'std'})"
    ]
   },
   {
@@ -129,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = ZRI_MF_long.merge(ZIPS,how = 'left', left_on = 'RegionName',right_on = 'zip')"
+    "ZRI_ZIP_Area = ZRI_MF_long.merge(ZIPS,how = 'left', left_on = 'RegionName',right_on = 'zip')"
    ]
   },
   {
@@ -138,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.merge(ZIP_Area[['area_land_meters','area_water_meters','area_land_miles','area_water_miles','zipcode']],\n",
+    "ZRI_ZIP_Area= ZRI_ZIP_Area.merge(ZIP_Area[['area_land_meters','area_water_meters','area_land_miles','area_water_miles','zipcode']],\n",
     "         how = 'left',\n",
     "         left_on = 'zip',\n",
     "         right_on = 'zipcode')"


### PR DESCRIPTION
Fix Jupyter Notebook's 9th cell, so it does not output an error. 
Erase an unnecessary column naming [std, mean] are already the names. 
Rename dataframes so that the names are more descriptive.